### PR TITLE
May cause error when use sh, should use bash

### DIFF
--- a/src/network-queues.sh
+++ b/src/network-queues.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 cpus=`fgrep -c processor /proc/cpuinfo`
 if [ $cpus -ge 32 ] ; then


### PR DESCRIPTION
# Linux Jessie 3.16.0-4-amd64 #1 SMP Debian 3.16.7-ckt11-1+deb8u3 (2015-08-04) x86_64 GNU/Linux
32: ./smp-lb.sh: cannot create /sys/class/net/eth0/queues/rx-$[1: Permission denied
33: ./smp-lb.sh: cannot create /sys/class/net/eth0/queues/rx-$[1: Permission denied
38: ./smp-lb.sh: cannot create /sys/class/net/eth0/queues/tx-$[1: Permission denied